### PR TITLE
test(defaults): switch to a default that is defined everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2115,7 @@ dependencies = [
  "duct",
  "envy",
  "git2",
+ "glob",
  "hex",
  "ignore",
  "itertools 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ testutils = { path = "./tests/testutils" }
 test-log = {version = "0.2.13", default-features = false, features = ["trace"]}
 pretty_assertions = "1.4.0"
 pretty_assertions_sorted = "1.2.3"
+glob = "0.3.1"

--- a/src/tasks/defaults/plist_utils.rs
+++ b/src/tasks/defaults/plist_utils.rs
@@ -30,13 +30,21 @@ Working out the rules for preferences was fairly complex, but if you run `defaul
 
 As far as I can tell, the rules are:
 
-- `NSGlobalDomain` -> `~/Library/Preferences/.GlobalPreferences.plist`
-- `~/Library/Containers/{domain}/Data/Library/Preferences/{domain}.plist` if it exists.
-- `~/Library/Preferences/{domain}.plist`
+### Normal Preferences
+
+- if `NSGlobalDomain` -> `~/Library/Preferences/.GlobalPreferences.plist`
+- if file exists -> `~/Library/Containers/{domain}/Data/Library/Preferences/{domain}.plist`
+- else -> `~/Library/Preferences/{domain}.plist`
 
 If none of these exist then create `~/Library/Preferences/{domain}.plist`.
 
-Note that `defaults domains` actually prints out `~/Library/Containers/{*}/Data/Library/Preferences/{*}.plist` (i.e. any plist file name inside a container folder), but `defaults read` only actually checks `~/Library/Containers/{domain}/Data/Library/Preferences/{domain}.plist` (a plist file whose name matches the container folder.
+Note that `defaults domains` actually prints out `~/Library/Containers/{*}/Data/Library/Preferences/{*}.plist` (i.e. any plist file name inside a container folder), but `defaults read` only actually checks `~/Library/Containers/{domain}/Data/Library/Preferences/{domain}.plist` (a plist file whose name matches the container folder).
+
+### `CurrentHost` / `ByHost` Preferences
+
+- if `NSGlobalDomain` -> `~/Library/Preferences/ByHost/.GlobalPreferences.{hardware_uuid}.plist`
+- if file exists -> `~/Library/Containers/{domain}/Data/Library/Preferences/ByHost/{domain}.{hardware_uuid}.plist` if it exists.
+- else -> `~/Library/Preferences/ByHost/{domain}.{hardware_uuid}.plist`
 
 ### Useful Resources
 

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -55,39 +55,24 @@ fn test_defaults_read_global() {
 fn test_defaults_read_local() {
     let temp_dir = testutils::temp_dir("up", testutils::function_path!()).unwrap();
 
-    // Four-letter codes for view modes: `icnv`, `clmv`, `glyv`, `Nlsv`
-    let mut expected_value = cmd!(
-        "defaults",
-        "read",
-        "com.apple.finder",
-        "FXPreferredViewStyle"
-    )
-    .read()
-    .unwrap();
+    // Dock region, e.g. 'GB'
+    let mut expected_value = cmd!("defaults", "read", "com.apple.dock", "region")
+        .read()
+        .unwrap();
     expected_value.push('\n');
 
     // Reading a normal value should have the same output as the defaults command (but yaml not
     // defaults own format).
     {
         let mut cmd = testutils::test_binary_cmd("up", &temp_dir);
-        cmd.args([
-            "defaults",
-            "read",
-            "com.apple.finder",
-            "FXPreferredViewStyle",
-        ]);
+        cmd.args(["defaults", "read", "com.apple.dock", "region"]);
         cmd.assert().success().stdout(expected_value.clone());
     }
 
     // A .plist extension should be allowed too.
     {
         let mut cmd = testutils::test_binary_cmd("up", &temp_dir);
-        cmd.args([
-            "defaults",
-            "read",
-            "com.apple.finder.plist",
-            "FXPreferredViewStyle",
-        ]);
+        cmd.args(["defaults", "read", "com.apple.dock.plist", "region"]);
         cmd.assert().success().stdout(expected_value.clone());
     }
 
@@ -98,10 +83,10 @@ fn test_defaults_read_local() {
             "defaults",
             "read",
             &format!(
-                "{}/Library/Preferences/com.apple.finder.plist",
+                "{}/Library/Preferences/com.apple.dock.plist",
                 dirs::home_dir().unwrap().display()
             ),
-            "FXPreferredViewStyle",
+            "region",
         ]);
         cmd.assert().success().stdout(expected_value);
     }


### PR DESCRIPTION


---

#### Commits _(oldest to newest)_

c05bc7a test(defaults): switch to a default that is defined everywhere

Turns out some machines don't have the FXPreferredViewStyle default set,
so pick another one that is hopefully unavoidable.

<br/>

e726f15 test(defaults): better error message when container plist test fails

Looks like some machines don't have Safari containerized for whatever
reason. In that case it would be useful to know what they do have
containerized.

<br/>

5745085 docs(defaults): document location of per-host defaults

Be extra clear as these are a bit confusing.

<br/>